### PR TITLE
Added support for j2 templating for the environment file via new extra vars argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ git clone https://github.com/cablelabs/snaps-orchestration.git
 
 # Cleanup Python runtime
 pip uninstall -y snaps-orchestration; pip freeze | xargs pip uninstall -y
-pip install -r snaps-orchestration/requirements.txt
+pip install -r snaps-orchestration/requirements-git.txt
 pip install -e snaps-orchestration/
 ```
 
@@ -22,7 +22,7 @@ Help](https://help.github.com/) is also outstanding.
 ## Executing Orchestration for OpenStack
 
 ```Bash
-python {repo_dir}/snaps-orchestration/openstack-launch.py -t {path to snaps template} -e {path to optional environment file for J2} [-d (for deploy)| -c (for cleanup)
+python {repo_dir}/snaps-orchestration/openstack-launch.py -t {path to snaps template} -e {path to optional environment file for J2} [-d "for deploy"| -c "for cleanup"]
 ```
 
 **Please see the [Quickstart](docs/quickstart.md) to get you started with a concrete example on deploying a simple scenario**

--- a/openstack-launch.py
+++ b/openstack-launch.py
@@ -41,6 +41,7 @@ def __run(arguments):
 
     logger.info('Starting to Deploy')
 
+    # Setup J2 Template variables
     extra_vars = __parse_ev(arguments.extra_vars)
     ev_env = Environment(loader=FileSystemLoader(
         searchpath=os.path.dirname(arguments.env_file)))
@@ -61,8 +62,7 @@ def __run(arguments):
         clean = arguments.clean is not ARG_NOT_SET
         clean_image = arguments.clean_image is not ARG_NOT_SET
         deploy = arguments.deploy is not ARG_NOT_SET
-        launch_utils.launch_config(
-            config, arguments.tmplt_file, deploy, clean, clean_image)
+        launch_utils.launch_config(config, deploy, clean, clean_image)
     else:
         logger.error(
             'Unable to read configuration file - ' + arguments.tmplt_file)

--- a/openstack-launch.py
+++ b/openstack-launch.py
@@ -21,7 +21,6 @@ from jinja2 import Environment, FileSystemLoader
 import os
 import yaml
 
-from snaps_common.file import file_utils
 from snaps_orch.openstack import launch_utils
 
 __author__ = 'spisarski'
@@ -43,17 +42,14 @@ def __run(arguments):
     logger.info('Starting to Deploy')
 
     extra_vars = __parse_ev(arguments.extra_vars)
-    if extra_vars:
-        ev_env = Environment(loader=FileSystemLoader(
-            searchpath=os.path.dirname(arguments.env_file)))
-        ev_tmplt = ev_env.get_template(os.path.basename(arguments.env_file))
-        env_str = ev_tmplt.render(**extra_vars)
-        env_dict = yaml.load(env_str)
-        env_dict.update(extra_vars)
-    else:
-        env_dict = file_utils.read_yaml(arguments.env_file)
+    ev_env = Environment(loader=FileSystemLoader(
+        searchpath=os.path.dirname(arguments.env_file)))
+    ev_tmplt = ev_env.get_template(os.path.basename(arguments.env_file))
+    env_str = ev_tmplt.render(**extra_vars)
+    env_dict = yaml.load(env_str)
+    env_dict.update(extra_vars)
 
-    # Apply env_file/substitution file to template
+    # Apply env_file and extra_vars file to template
     env = Environment(loader=FileSystemLoader(
         searchpath=os.path.dirname(arguments.tmplt_file)))
     template = env.get_template(os.path.basename(arguments.tmplt_file))

--- a/requirements-git.txt
+++ b/requirements-git.txt
@@ -1,0 +1,2 @@
+git+https://github.com/cablelabs/snaps-common@master#egg=snaps-common
+git+https://gerrit.opnfv.org/gerrit/snaps@master#egg=snaps-oo

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ mock
 PyYAML
 jinja2
 git+https://github.com/cablelabs/snaps-common@master#egg=snaps-common
-git+https://gerrit.opnfv.org/gerrit/snaps@master#egg=snaps
+git+https://gerrit.opnfv.org/gerrit/snaps@master#egg=snaps-oo
 keystoneauth1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 mock
 PyYAML
 jinja2
-git+https://github.com/cablelabs/snaps-common@master#egg=snaps-common
-git+https://gerrit.opnfv.org/gerrit/snaps@master#egg=snaps-oo
 keystoneauth1

--- a/tests/openstack/launch_utils.py
+++ b/tests/openstack/launch_utils.py
@@ -54,4 +54,4 @@ class LaunchUtilsTests(unittest.TestCase):
         # self.assertIsNotNone(m1)
         # self.assertIsNotNone(m2)
         launch_utils.launch_config(
-            self.pb_dict, self.pb_loc, True, False, False)
+            self.pb_dict, True, False, False)


### PR DESCRIPTION
#### What does this PR do?
Adds optional support to openstack-launch for env files and j2 templating. When the environment file contains j2 encodings, the openstack-launch client will leverage the -v option to list key/values to substitute in the environment file as well as act as an override to env file values that will be applied to the snaps-oo template file. This will give our CI processes much more flexibility running snaps orchestration scripts.

i.e.:
openstack-launch -t {snaps tmplt file} -e {env_file} -d -v snaps_k8s_dir=/home/spisarski/IdeaProjects/cablelabs/snaps/snaps-kubernetes build_id=spisarsk-k8s

#### Do you have any concerns with this PR?
no
#### How can the reviewer verify this PR?
run the current k8s CI scripts, remove the sed command to replace the src and build_id values and change the command line call to openstack-launch to include build_id, snaps_k8s_dir
#### Any background context you want to provide?
#### Screenshots or logs (if appropriate)
#### Questions:
- Have you connected this PR to the issue it resolves?
- Does the documentation need an update?
- Does this add new Python dependencies?
- Have you added unit or functional tests for this PR?
- Does this patch update any configuration files?
